### PR TITLE
set the gauge color to follow color palette

### DIFF
--- a/src/traces/indicator/attributes.js
+++ b/src/traces/indicator/attributes.js
@@ -299,7 +299,7 @@ module.exports = {
             ].join(' ')
         },
         bar: extendDeep({}, gaugeBarAttrs, {
-            color: {dflt: 'green'},
+            color: {dflt: colorAttrs.defaults[0]},
             description: [
                 'Set the appearance of the gauge\'s value'
             ].join(' ')


### PR DESCRIPTION
https://github.com/plotly/plotly.js/issues/4311 

This PR changes the default color for the indicator gauge bar to be the first color in the default palette rather than just green. Since green has a connotation of success, it would make sense to have a more natural color be the default.

It is fairly simple for a user to change the color back to green but more difficult to fetch the default layout color.